### PR TITLE
first pass at travis-ci build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ install:
 - npm install
 script:
 - npm run build
+after_success:
+  - scripts/post_build.py
 before_deploy:
 - git config --global user.email "builds@travis-ci.com"
 - git config --global user.name "Travis CI"

--- a/scripts/post_build.py
+++ b/scripts/post_build.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import hashlib
+
+# set up build dir paths
+build_dir = 'out/make'
+full_path = os.path.abspath(build_dir)
+
+# travis tag
+travis_tag = os.environ['TRAVIS_TAG']
+
+# shasums file based on tag
+shasums_file = 'augur-app-' + travis_tag + '-SHASUMS'
+
+# change to build dir
+os.chdir(full_path)
+
+# gather sha256 sums of all files in package dir
+shasums = ''
+for fname in os.listdir(full_path):
+    sha = hashlib.sha256(open(fname, 'rb').read()).hexdigest()
+    shasums += '{} {}'.format(sha, fname)
+
+# write out sha sums
+with open(shasums_file, "a") as shafile:
+    shafile.write(shasums)


### PR DESCRIPTION
this should only run on tags.
 * linux + mac builds
 * token was generated with `travis setup releases`

we should add checksum files as part of the post/install pre-release process