### PR TITLE
eth_call issue can occur locally as well, if geth is overloaded

### DIFF
--- a/src/main/augurNodeServer.js
+++ b/src/main/augurNodeServer.js
@@ -11,7 +11,7 @@ const REMOTE_DELAY_WAIT = 60*1000;
 const LOCAL_DELAY_WAIT = 1*1000;
 
 const REMOTE_MAX_RETRIES = 5;
-const LOCAL_MAX_RETRIES = 0;
+const LOCAL_MAX_RETRIES = 3;
 
 const defaultConfig = {
   'network': 'mainnet',


### PR DESCRIPTION
why not contribute to that overloading