### PR TITLE
set to original location, changed by mistake

### DIFF
--- a/src/main/gethNodeController.js
+++ b/src/main/gethNodeController.js
@@ -73,7 +73,10 @@ GethNodeController.prototype.start = function (event) {
   }
 
   const staticNodesPath = path.join(gethPath, 'geth', 'static-nodes.json')
-  fs.writeFileSync(staticNodesPath, JSON.stringify(PEER_NODES, null, 4))
+  if (!fs.existsSync(staticNodesPath)) {
+    fs.writeFileSync(staticNodesPath, JSON.stringify(PEER_NODES, null, 4))
+  }
+
   this.gethProcess = spawn(this.gethExecutablePath, [
     '--syncmode=light',
     '--cache=512',

--- a/src/main/gethNodeController.js
+++ b/src/main/gethNodeController.js
@@ -71,7 +71,8 @@ GethNodeController.prototype.start = function (event) {
   if (!fs.existsSync(gethPath)) {
     fs.mkdirSync(gethPath)
   }
-  const staticNodesPath = path.join(gethPath, 'static-nodes.json')
+
+  const staticNodesPath = path.join(gethPath, 'geth', 'static-nodes.json')
   fs.writeFileSync(staticNodesPath, JSON.stringify(PEER_NODES, null, 4))
   this.gethProcess = spawn(this.gethExecutablePath, [
     '--syncmode=light',


### PR DESCRIPTION
In previous PR, mistakenly moved the location of the static nodes json file.

only save static nodes to disk if it doesn't exist.


This doesn't address the mac light node not starting issue.