### PR TITLE
add full path to run geth light node

### DIFF
--- a/src/main/gethNodeController.js
+++ b/src/main/gethNodeController.js
@@ -1,4 +1,4 @@
-const { ipcMain } = require('electron')
+const { ipcMain, app} = require('electron')
 const { spawn } = require('child_process')
 const { request } = require('http')
 const fs = require('fs')
@@ -45,12 +45,12 @@ const PEER_COUNT_REQUEST_OPTIONS = {
   }
 }
 
-function GethNodeController(basePath) {
+function GethNodeController() {
   this.window = null
   let os = 'linux'
   if (process.platform === 'win32') os = 'win'
   if (process.platform === 'darwin') os = 'mac'
-  this.gethExecutablePath = path.join(basePath, `resources/${os}/geth`)
+  this.gethExecutablePath = path.join(app.getAppPath(), `resources/${os}/geth`)
   this.gethProcess = null
   this.statusLoop = null
   ipcMain.on('toggleGeth', this.toggle.bind(this))

--- a/src/main/gethNodeController.js
+++ b/src/main/gethNodeController.js
@@ -45,12 +45,12 @@ const PEER_COUNT_REQUEST_OPTIONS = {
   }
 }
 
-function GethNodeController() {
+function GethNodeController(basePath) {
   this.window = null
   let os = 'linux'
   if (process.platform === 'win32') os = 'win'
   if (process.platform === 'darwin') os = 'mac'
-  this.gethExecutablePath = `resources/${os}/geth`
+  this.gethExecutablePath = path.join(basePath, `resources/${os}/geth`)
   this.gethProcess = null
   this.statusLoop = null
   ipcMain.on('toggleGeth', this.toggle.bind(this))

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -20,7 +20,7 @@ let mainWindow
 
 const augurNodeController = new AugurNodeController()
 const augurUIServer = new AugurUIServer()
-const gethNodeController = new GethNodeController()
+const gethNodeController = new GethNodeController(app.getAppPath())
 
 const path = require('path')
 const url = require('url')

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -20,7 +20,7 @@ let mainWindow
 
 const augurNodeController = new AugurNodeController()
 const augurUIServer = new AugurUIServer()
-const gethNodeController = new GethNodeController(app.getAppPath())
+const gethNodeController = new GethNodeController()
 
 const path = require('path')
 const url = require('url')


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/15164/local-light-node-option-broken

fixes geth execution path on windows, need to check installer for win and linux.