### PR TITLE
improve windows scroll so things aren't pushed over

### DIFF
--- a/src/renderer/app/App.js
+++ b/src/renderer/app/App.js
@@ -135,8 +135,8 @@ export class App extends Component {
             <ModalDownloadGeth closeModal={this.cancelDownload} download={this.downloadGeth} />
           </div>
         }
-        <div className={Styles.App__connectingContainer}>
-          <div className={Styles.App__scrollContainer}>
+        <div className={Styles.App__scrollContainer}>
+          <div className={Styles.App__scrollContainerApp}>
             <div className={Styles.App__row}>
               <Logo />
               <SettingsDropdown
@@ -155,6 +155,8 @@ export class App extends Component {
               {(serverStatus.AUGUR_NODE_CONNECTED || serverStatus.GETH_CONNECTED)  ? 'Disconnect' : 'Connect'}
             </button>
           </div>
+        </div>
+        <div className={Styles.App__connectingContainer}>
           <div style={{marginTop: '195px', overflowY: 'hidden', maxHeight: '490px', paddingBottom: '10px'}}>
             <ConnectingView
               connected={serverStatus.AUGUR_NODE_CONNECTED || (serverStatus.GETH_CONNECTED && serverStatus.GETH_FINISHED_SYNCING && !serverStatus.GETH_SYNCING)}

--- a/src/renderer/app/app.styles.less
+++ b/src/renderer/app/app.styles.less
@@ -60,8 +60,12 @@
     top: 28px;
     background-color: @color-almostblack;
     z-index: 1;
-    max-width: 306px;
-    width: 306px;
+    left: 0;
+    right: 0;
+}
+
+:local(.App__scrollContainerApp) {
+	padding: 0 24px;
 }
 
 :local(.App__row) {

--- a/src/renderer/app/components/processing-view/processing-view.styles.less
+++ b/src/renderer/app/components/processing-view/processing-view.styles.less
@@ -24,7 +24,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-	padding: 16px 16px;
+	padding: 24px 16px;
 }
 
 :local(.ProcessingView__processingTitle) {


### PR DESCRIPTION
scroll bar improvement. so no more overlap when it is condensed

<img width="391" alt="screen shot 2018-09-08 at 5 43 27 pm" src="https://user-images.githubusercontent.com/6775839/45259989-b8165780-b38e-11e8-9a5f-23b5874f5efa.png">
<img width="374" alt="screen shot 2018-09-08 at 5 42 53 pm" src="https://user-images.githubusercontent.com/6775839/45259990-b8165780-b38e-11e8-9d60-fcc1b1d131fb.png">

mac:
<img width="385" alt="screen shot 2018-09-08 at 5 43 47 pm" src="https://user-images.githubusercontent.com/6775839/45259991-c82e3700-b38e-11e8-892d-8f04c7ae300c.png">
