### PR TITLE
use margin instead of padding for expanded details so arrow is clickable

### DIFF
--- a/src/renderer/app/components/processing-view/processing-view.styles.less
+++ b/src/renderer/app/components/processing-view/processing-view.styles.less
@@ -109,8 +109,8 @@
 }
 
 :local(.ProcessingView__blocksInfo) {
-  margin-bottom: 40px;
-  padding: 70px 3px;
+  padding: 0 3px;
+  margin-top: 75px;
 }
 
 :local(.ProcessingView__blocksBehind) {


### PR DESCRIPTION
looks the same but now arrow is clickable when expanded
<img width="803" alt="screen shot 2018-09-09 at 10 29 40 am" src="https://user-images.githubusercontent.com/6775839/45267128-8c8d7e80-b41b-11e8-9fd1-13903bf7822c.png">
