### PR TITLE
Fix HTTP & WS validators

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "file-loader": "^2.0.0",
     "helmet": "3.13.0",
     "immutable-delete": "^1.1.0",
+    "ip-port-regex": "^2.0.0",
     "knex": "0.14.6",
     "lodash": "^4.17.10",
     "node-pre-gyp": "~0.6.38",
@@ -67,6 +68,7 @@
     "source-map-support": "^0.5.9",
     "sqlite3": "4.0.2",
     "style-loader": "^0.22.1",
+    "url-regex": "^4.1.1",
     "webpack-cli": "^3.1.0"
   },
   "devDependencies": {

--- a/src/renderer/common/components/modal/components/modal-edit-connection/modal-edit-connection.js
+++ b/src/renderer/common/components/modal/components/modal-edit-connection/modal-edit-connection.js
@@ -1,3 +1,6 @@
+const ipPortRegex = require("ip-port-regex");
+const urlRegex = require("url-regex");
+
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
@@ -62,7 +65,6 @@ export default class ModalEditConnection extends Component {
   validateField(name, value) {
     const { connections } = this.props
     let { validations, disableButton } = this.state
-    const urlRegex = /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/
 
     if (name === 'name') {
       const nameRepeat = (Object.values(connections || [])).find(network => network.name.toLowerCase() === value.toLowerCase())
@@ -72,16 +74,24 @@ export default class ModalEditConnection extends Component {
         delete validations[name]
       }
     } else if (name === 'http') {
-      if (value !== '' && !value.match(urlRegex)) {
-        validations[name] = 'Not a valid HTTP Endpoint'
-      } else {
+      const urlProtocol = value.substring(0, value.indexOf('://'))
+      const urlProtocolIsValid = urlProtocol === '' || urlProtocol === 'http' || urlProtocol === 'https'
+      const urlWithoutProtocol = value.replace(/^https?:\/\//, '')
+
+      if (urlProtocolIsValid && (urlRegex({exact: true}).test(value) || ipPortRegex({exact: true}).test(urlWithoutProtocol))) {
         delete validations[name]
+      } else {
+        validations[name] = 'Not a valid HTTP Endpoint'
       }
     } else if (name === 'ws') {
-      if (value !== '' && !value.match(urlRegex)) {
-        validations[name] = 'Not a valid Websocket Endpoint'
-      } else {
+      const urlProtocol = value.substring(0, value.indexOf('://'))
+      const urlProtocolIsValid = urlProtocol === '' || urlProtocol === 'ws' || urlProtocol === 'wss'
+      const urlWithoutProtocol = value.replace(/^wss?:\/\//, '')
+
+      if (urlProtocolIsValid && (urlRegex({exact: true}).test(value) || ipPortRegex({exact: true}).test(urlWithoutProtocol))) {
         delete validations[name]
+      } else {
+        validations[name] = 'Not a valid Websocket Endpoint'
       }
     }
 


### PR DESCRIPTION
[CH issue](https://app.clubhouse.io/augur/story/16569/allow-endpoints-with-ip-addresses)

Do not warn user for endpoints with IP address and warn user for protocols other than http(s) and ws(s).