### PR TITLE
start augur ui server sooner, found bug when augur ui server is resta…

### DIFF
--- a/src/main/augurUIServer.js
+++ b/src/main/augurUIServer.js
@@ -125,9 +125,14 @@ AugurUIServer.prototype.onStopUiServer = function () {
 }
 
 AugurUIServer.prototype.restart = function (event) {
-  if (this.server !== null) this.onStopUiServer()
-  if (this.httpListener) this.httpListener.close()
-  this.startServer(event)
+  if (this.server !== null) {
+    this.server.close(() => {
+      if (this.httpListener) this.httpListener.close()
+      this.startServer(event)
+    })
+  } else {
+    this.startServer(event)
+  }
 }
 
 AugurUIServer.prototype.createSSLCertificates = function (event) {

--- a/src/main/augurUIServer.js
+++ b/src/main/augurUIServer.js
@@ -126,6 +126,7 @@ AugurUIServer.prototype.onStopUiServer = function () {
 
 AugurUIServer.prototype.restart = function (event) {
   if (this.server !== null) this.onStopUiServer()
+  if (this.httpListener) this.httpListener.close()
   this.startServer(event)
 }
 

--- a/src/renderer/app/actions/local-server-cmds.js
+++ b/src/renderer/app/actions/local-server-cmds.js
@@ -25,6 +25,7 @@ export const startAugurNode = () => {
   const { networks } = store.getState().configuration
   const selected = Object.values(networks).find(n => n.selected)
   ipcRenderer.send(START_AUGUR_NODE, selected)
+  startUiServer()
 }
 
 export const stopAugurNode = () => {
@@ -44,11 +45,11 @@ export const stopGethNode = () => {
 }
 
 export const saveConfiguration = (config) => {
+  startUiServer() // start UI server ssl setting might have changed
   ipcRenderer.send(SAVE_CONFIG, config)
 }
 
 export const openAugurUi = (networkConfig) => {
-  startUiServer() // start UI server before connecting
   const { sslEnabled, sslPort, uiPort } = store.getState().configuration
   const protocol = sslEnabled ? 'https' : 'http'
   const port = sslEnabled ? sslPort : uiPort


### PR DESCRIPTION
…rted and ssl is enabled the reset doesn't clean up http listener


https://app.clubhouse.io/augur/story/16744/feature-request-start-web-server-with-augur-node


test that augur ui server is started when augur-node is started, test switch between ssl enabled/ disabled. 