### PR TITLE
Shutdown subsystems (and geth) on electron 'will-quit' event

### DIFF
--- a/src/main/gethNodeController.js
+++ b/src/main/gethNodeController.js
@@ -162,7 +162,7 @@ GethNodeController.prototype.updatePeerCount = function (peerCountHex) {
     const peerCount = parseInt(peerCountHex, 16)
     this.sendMsgToWindowContents(PEER_COUNT_DATA, { peerCount })
     // Wait until we have MIN_PEERS peers to reduce the chances of a drop in peers leaving us suddenly broken and wait PRE_SYNC_WAIT_TIME ms before requesting sync status in a very naive attempt to avoid hitting the case where it has a peer but hasn't begun syncing yet
-    if (peerCount >= MIN_PEERS) setTimeout(this.makeRequest.bind(this), PRE_SYNC_WAIT_TIME, SYNCING_REQUEST_OPTIONS, SYNCING_POST_DATA, this.updateSyncData.bind(this));
+    if (peerCount >= MIN_PEERS) setTimeout(this.makeRequest.bind(this), PRE_SYNC_WAIT_TIME, SYNCING_REQUEST_OPTIONS, SYNCING_POST_DATA, this.updateSyncData.bind(this))
   } catch (err) {
     this.sendMsgToWindowContents(ERROR_NOTIFICATION, {
       messageType: GETH_REMOTE_MSG,

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -26,6 +26,12 @@ const augurNodeController = new AugurNodeController(selectedNetwork)
 const augurUIServer = new AugurUIServer()
 const gethNodeController = new GethNodeController()
 
+function stopAllSubsystems() {
+  augurNodeController.shutDownServer()
+  augurUIServer.onStopUiServer()
+  gethNodeController.onStopGethServer()
+}
+
 const path = require('path')
 const url = require('url')
 
@@ -166,12 +172,10 @@ const createWindow = debounce(function() {
   mainWindow.on('closed', function() {
     log.info('mainWindow on closed')
     try {
+      stopAllSubsystems()
       // Dereference the window object, usually you would store windows
       // in an array if your app supports multi windows, this is the time
       // when you should delete the corresponding element.
-      augurNodeController.shutDownServer()
-      augurUIServer.onStopUiServer()
-      gethNodeController.onStopGethServer()
       mainWindow = null
     } catch (err) {
       log.error(err)
@@ -219,6 +223,8 @@ app.on('window-all-closed', function() {
     app.quit()
   }
 })
+
+app.on('will-quit', stopAllSubsystems) // in certain cases, on certain platforms, stopping all subsystems on 'will-quit' may prevent subsystems from failing to shutdown, such as a dangling gethNode process. Typically stopAllSubsystems() will be executed at least twice, once on mainWindow.'closed' and once on 'will-quit'.
 
 app.on('activate', function() {
   log.info('app on activate')


### PR DESCRIPTION
Fixes AugurProject/augur#261

I was also able to cause geth to quit without properly cleaning up the
UDP listener socket used for p2p discovery. For this I opened a new
issue https://github.com/ethereum/go-ethereum/issues/18443.